### PR TITLE
Fix java 15 uplift

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ We can do this by updating the `pom.xml` as follows:
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </exclusion>
+        <exclusion>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
     </exclusions>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -8,10 +8,15 @@
     <artifactId>rest-demo-2</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <java.version>15</java.version>
+        <spring.boot.version>2.3.7.RELEASE</spring.boot.version>
+    </properties>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
+        <version>2.3.7.RELEASE</version>
     </parent>
 
     <dependencies>
@@ -29,6 +34,10 @@
                 <exclusion>
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -51,15 +60,10 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>1.18.16</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <properties>
-        <java.version>13</java.version>
-        <spring.boot.version>2.2.5.RELEASE</spring.boot.version>
-    </properties>
 
     <build>
         <plugins>


### PR DESCRIPTION
Update java, spring and lombok versions in line with java 15.

Also include the exclusion for junit vintage engine in pom.xml, this means we will pull in the jupiter engine instead for running junit 5 tests. Without this tests are not found